### PR TITLE
Reduce CPU, memory, and egress on Railway

### DIFF
--- a/src/algos/navyfragen.ts
+++ b/src/algos/navyfragen.ts
@@ -8,10 +8,20 @@ type FeedResult = { cursor: string | undefined; feed: { post: string }[] }
 type CacheEntry = { result: FeedResult; expires: number }
 
 const feedCache = new Map<string, CacheEntry>()
-const CACHE_TTL_MS = 30_000
+const CACHE_TTL_MS = 5 * 60_000 // 5 minutes; invalidated early when new posts arrive
 
-// Invalidate feed cache on new data (called by subscription)
-export const invalidateFeedCache = () => feedCache.clear()
+// Throttle invalidations to at most once per 60s so the cache stays warm
+// during rapid bursts of matching posts.
+let lastInvalidatedAt = 0
+const MIN_INVALIDATION_INTERVAL_MS = 60_000
+
+export const invalidateFeedCache = () => {
+  const now = Date.now()
+  if (now - lastInvalidatedAt >= MIN_INVALIDATION_INTERVAL_MS) {
+    feedCache.clear()
+    lastInvalidatedAt = now
+  }
+}
 
 const getCacheKey = (params: QueryParams) =>
   `${params.limit}:${params.cursor ?? ''}`

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -9,7 +9,7 @@ export const createDb = (location: string): Database => {
   db.pragma('synchronous = NORMAL')
   db.pragma('foreign_keys = ON')
   db.pragma('temp_store = MEMORY')
-  db.pragma('mmap_size = 30000000000') // 30GB
+  db.pragma('mmap_size = 134217728') // 128MB
   db.pragma('cache_size = -2000') // 2MB
   return new Kysely<DatabaseSchema>({
     dialect: new SqliteDialect({

--- a/src/methods/feed-generation.ts
+++ b/src/methods/feed-generation.ts
@@ -15,8 +15,8 @@ const unauthenticatedRateLimiter = new Map<
 >()
 
 const RATE_LIMIT_WINDOW_MS = 60 * 1000
-const MAX_REQUESTS_PER_WINDOW_AUTH = 10
-const MAX_REQUESTS_PER_WINDOW_UNAUTH = 5
+const MAX_REQUESTS_PER_WINDOW_AUTH = 4
+const MAX_REQUESTS_PER_WINDOW_UNAUTH = 2
 const CLEANUP_INTERVAL_MS = 5 * 60 * 1000 // 5 minutes
 
 const cleanupRateLimiters = () => {

--- a/src/server.ts
+++ b/src/server.ts
@@ -78,7 +78,7 @@ export class FeedGenerator {
 
     const limiter = rateLimit({
       windowMs: 15 * 60 * 1000,
-      max: 50, // 50 requests per 15 minutes per IP
+      max: 20, // 20 requests per 15 minutes per IP
       standardHeaders: true,
       legacyHeaders: false,
       message: 'Too many requests, please try again later.',
@@ -88,14 +88,14 @@ export class FeedGenerator {
     // Speed limiting (slow down repetitive requests)
     const speedLimiter = slowDown({
       windowMs: 15 * 60 * 1000,
-      delayAfter: 20, // start adding delay after 20 requests
-      delayMs: (hits) => hits * 150,
+      delayAfter: 5, // start adding delay after 5 requests
+      delayMs: (hits) => hits * 500,
     })
     app.use(speedLimiter)
 
-    // Cache-Control for feed skeleton: 30s public cache matches in-process feed cache TTL
+    // Cache-Control for feed skeleton: matches the 5-minute in-process feed cache TTL
     app.use('/xrpc/app.bsky.feed.getFeedSkeleton', (_req, res, next) => {
-      res.set('Cache-Control', 'public, max-age=30, stale-while-revalidate=60')
+      res.set('Cache-Control', 'public, max-age=300, stale-while-revalidate=60')
       next()
     })
 

--- a/src/util/subscription.ts
+++ b/src/util/subscription.ts
@@ -1,7 +1,6 @@
 import { Subscription } from '@atproto/xrpc-server'
 import { cborToLexRecord, readCar } from '@atproto/repo'
-import { BlobRef } from '@atproto/lexicon'
-import { ids, lexicons } from '../lexicon/lexicons'
+import { ids } from '../lexicon/lexicons'
 import { Record as PostRecord } from '../lexicon/types/app/bsky/feed/post'
 import {
   Commit,
@@ -85,15 +84,20 @@ export abstract class FirehoseSubscriptionBase {
 }
 
 export const getOpsByType = async (evt: Commit): Promise<OperationsByType> => {
-  const car = await readCar(evt.blocks)
   const opsByType: OperationsByType = {
     posts: { creates: [], deletes: [] },
   }
 
-  for (const op of evt.ops) {
-    const [collection] = op.path.split('/')
-    if (collection !== ids.AppBskyFeedPost) continue
+  // Pre-filter to only feed-post ops before doing expensive CAR parsing.
+  // Most commits are likes, follows, reposts, etc. — skip them entirely.
+  const postOps = evt.ops.filter(
+    (op) => op.path.split('/')[0] === ids.AppBskyFeedPost,
+  )
+  if (postOps.length === 0) return opsByType
 
+  const car = await readCar(evt.blocks)
+
+  for (const op of postOps) {
     const uri = `at://${evt.repo}/${op.path}`
 
     if (op.action === 'create') {
@@ -137,35 +141,15 @@ type DeleteOp = {
   uri: string
 }
 
+// Fast duck-type check — avoids full schema validation + recursive fixBlobRefs
+// on every post in the firehose hot path.
 export const isPost = (obj: unknown): obj is PostRecord => {
-  return isType(obj, ids.AppBskyFeedPost)
-}
-
-const isType = (obj: unknown, nsid: string) => {
-  try {
-    lexicons.assertValidRecord(nsid, fixBlobRefs(obj))
-    return true
-  } catch (err) {
-    return false
-  }
-}
-
-const fixBlobRefs = (obj: unknown): unknown => {
-  if (Array.isArray(obj)) {
-    return obj.map(fixBlobRefs)
-  }
-  if (obj && typeof obj === 'object') {
-    if (obj.constructor.name === 'BlobRef') {
-      const blob = obj as BlobRef
-      return new BlobRef(blob.ref, blob.mimeType, blob.size, blob.original)
-    }
-    for (const key in obj) {
-      if (Object.prototype.hasOwnProperty.call(obj, key)) {
-        ;(obj as Record<string, unknown>)[key] = fixBlobRefs(
-          (obj as Record<string, unknown>)[key],
-        )
-      }
-    }
-  }
-  return obj
+  return (
+    obj !== null &&
+    typeof obj === 'object' &&
+    '$type' in obj &&
+    (obj as Record<string, unknown>)['$type'] === ids.AppBskyFeedPost &&
+    'text' in obj &&
+    typeof (obj as Record<string, unknown>)['text'] === 'string'
+  )
 }


### PR DESCRIPTION
## Summary

- **Skip CAR parsing for non-post firehose events** — the biggest CPU win. Most commits (likes, follows, reposts, profile updates) were previously having their full CAR block parsed before we discovered they had no feed posts. Now we pre-filter ops by collection first and only call `readCar` when there's at least one `app.bsky.feed.post` op.
- **Fast `isPost` duck-type check** — replaced the full lexicon schema validation + recursive `fixBlobRefs` walk (runs on every firehose post) with a simple field presence check. ATProto firehose events are already typed; full validation here was expensive overhead with no practical benefit.
- **Longer feed cache TTL + throttled invalidation** — cache TTL raised from 30s to 5 minutes. Cache invalidation is now throttled to at most once per 60s to keep the cache warm during rapid bursts of matching posts. Cache-Control header updated to match (`max-age=300`).
- **SQLite mmap_size 30 GB → 128 MB** — the 30 GB hint was unnecessary virtual address space on a constrained Railway container.
- **Tighter rate limits** — global: 50→20 req/15 min; slow-down threshold: 20→5 req (500 ms/hit); per-endpoint auth: 10→4 req/min; per-endpoint unauth: 5→2 req/min.

## Test plan

- [ ] Deploy to Railway staging and confirm the service starts and connects to the firehose
- [ ] Verify feed responses still return valid post skeletons
- [ ] Confirm rate limits are enforced (expect 429 after 4 req/min authenticated)
- [ ] Monitor Railway metrics for CPU and memory reduction after deploy

https://claude.ai/code/session_015EES8cpnfLkjQQc74S3jww

---
_Generated by [Claude Code](https://claude.ai/code/session_015EES8cpnfLkjQQc74S3jww)_