### PR TITLE
Fix build: restore lexicons import removed by accident

### DIFF
--- a/src/util/subscription.ts
+++ b/src/util/subscription.ts
@@ -1,6 +1,6 @@
 import { Subscription } from '@atproto/xrpc-server'
 import { cborToLexRecord, readCar } from '@atproto/repo'
-import { ids } from '../lexicon/lexicons'
+import { ids, lexicons } from '../lexicon/lexicons'
 import { Record as PostRecord } from '../lexicon/types/app/bsky/feed/post'
 import {
   Commit,


### PR DESCRIPTION
## Summary

- Restores `lexicons` to the import in `src/util/subscription.ts` — it was accidentally dropped when `BlobRef` was removed in #7, but `lexicons.assertValidXrpcMessage` is still used in the `FirehoseSubscriptionBase` constructor for WebSocket message validation.

Fixes the Railway build failure: `error TS2304: Cannot find name 'lexicons'`.

## Test plan

- [ ] Confirm `yarn build` / `tsc` succeeds
- [ ] Deploy to Railway and verify service starts

https://claude.ai/code/session_015EES8cpnfLkjQQc74S3jww

---
_Generated by [Claude Code](https://claude.ai/code/session_015EES8cpnfLkjQQc74S3jww)_