### PR TITLE
Fix express-rate-limit X-Forwarded-For validation error

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -38,6 +38,7 @@ export class FeedGenerator {
 
   static create(cfg: Config) {
     const app = express()
+    app.set('trust proxy', 1)
 
     // Security headers
     app.use(helmet())


### PR DESCRIPTION
## Summary

- Adds `app.set('trust proxy', 1)` immediately after creating the Express app in `src/server.ts`
- Fixes the `ERR_ERL_UNEXPECTED_X_FORWARDED_FOR` `ValidationError` thrown by `express-rate-limit` when the app runs behind a proxy (e.g. Railway/container environment) that sets the `X-Forwarded-For` header

## Test plan

- [ ] Start the server in the container environment and confirm no `ValidationError` appears in logs
- [ ] Verify rate limiting still works correctly (requests from the same IP are tracked and limited)

https://claude.ai/code/session_0128kAh44qMEwLHXcSsTxNK5

---
_Generated by [Claude Code](https://claude.ai/code/session_0128kAh44qMEwLHXcSsTxNK5)_