### PR TITLE
Fix health-check CI: adapt to auth-protected skeleton endpoint

### DIFF
--- a/.github/workflows/dev-integration.yml
+++ b/.github/workflows/dev-integration.yml
@@ -1,0 +1,68 @@
+name: Dev integration test
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  integration:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'yarn'
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Start feed generator in dev mode
+        env:
+          FEEDGEN_PORT: 3000
+          FEEDGEN_LISTENHOST: 127.0.0.1
+          FEEDGEN_PUBLISHER_DID: did:example:ci
+          FEEDGEN_REQUIRE_AUTH: 'false'
+        run: yarn start &> /tmp/feed-server.log &
+
+      - name: Wait for server to be ready
+        run: |
+          for i in $(seq 1 30); do
+            if curl -sf --max-time 2 \
+              http://127.0.0.1:3000/xrpc/app.bsky.feed.describeFeedGenerator > /dev/null 2>&1; then
+              echo "Server ready after ${i}s"
+              break
+            fi
+            if [ "$i" -eq 30 ]; then
+              echo "Server did not start in time. Logs:"
+              cat /tmp/feed-server.log
+              exit 1
+            fi
+            sleep 1
+          done
+
+      - name: Check describeFeedGenerator
+        run: |
+          response=$(curl -sf http://127.0.0.1:3000/xrpc/app.bsky.feed.describeFeedGenerator)
+          echo "$response" | jq .
+          echo "$response" | jq -e '.feeds | length > 0' > /dev/null
+
+      - name: Check getFeedSkeleton returns feed array
+        run: |
+          feed_uri="at://did:example:ci/app.bsky.feed.generator/navyfragen"
+          response=$(curl -sf \
+            "http://127.0.0.1:3000/xrpc/app.bsky.feed.getFeedSkeleton?feed=${feed_uri}&limit=10")
+          echo "$response" | jq .
+          echo "$response" | jq -e 'has("feed")' > /dev/null
+          echo "Feed structure valid ($(echo "$response" | jq '.feed | length') posts in dev DB)"
+
+      - name: Check well-known DID document
+        run: |
+          curl -sf http://127.0.0.1:3000/.well-known/did.json | jq .
+
+      - name: Print server log on failure
+        if: failure()
+        run: cat /tmp/feed-server.log

--- a/.github/workflows/dev-integration.yml
+++ b/.github/workflows/dev-integration.yml
@@ -8,6 +8,9 @@ on:
 permissions:
   contents: read
 
+permissions:
+  contents: read
+
 jobs:
   integration:
     runs-on: ubuntu-latest

--- a/.github/workflows/dev-integration.yml
+++ b/.github/workflows/dev-integration.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   integration:
     runs-on: ubuntu-latest

--- a/.github/workflows/health-check.yml
+++ b/.github/workflows/health-check.yml
@@ -23,28 +23,27 @@ jobs:
           feed_uri=$(echo "$response" | jq -r '.feeds[0].uri')
           echo "feed_uri=$feed_uri" >> "$GITHUB_OUTPUT"
 
-      - name: Fetch feed skeleton
+      - name: Verify auth enforcement on feed skeleton
         id: skeleton
         run: |
           feed_uri="${{ steps.describe.outputs.feed_uri }}"
-          response=$(curl -sf --max-time 15 --compressed \
-            "https://feed.navyfragen.app/xrpc/app.bsky.feed.getFeedSkeleton?feed=${feed_uri}&limit=30")
-          echo "$response" | jq .
-          # Fail if response doesn't have a feed key
-          echo "$response" | jq -e 'has("feed")' > /dev/null
-          # Warn (but don't fail) if feed is empty
-          count=$(echo "$response" | jq '.feed | length')
-          echo "Post count: $count"
-          if [ "$count" -eq 0 ]; then
-            echo "::warning::Feed returned 0 posts — firehose may not be indexing or database is empty"
+          status=$(curl -s -o /dev/null -w "%{http_code}" --max-time 15 \
+            "https://feed.navyfragen.app/xrpc/app.bsky.feed.getFeedSkeleton?feed=${feed_uri}&limit=1")
+          echo "HTTP status: $status"
+          if [ "$status" = "401" ]; then
+            echo "Auth correctly enforced (HTTP 401)"
+          elif [ "$status" = "200" ]; then
+            echo "::warning::Feed returned 200 without auth — FEEDGEN_REQUIRE_AUTH may be set to false"
+          else
+            echo "::error::Unexpected status $status from getFeedSkeleton"
+            exit 1
           fi
 
       - name: Check gzip compression is active
         run: |
-          feed_uri="${{ steps.describe.outputs.feed_uri }}"
           headers=$(curl -sI --max-time 15 \
             -H "Accept-Encoding: gzip, deflate, br" \
-            "https://feed.navyfragen.app/xrpc/app.bsky.feed.getFeedSkeleton?feed=${feed_uri}&limit=1")
+            "https://feed.navyfragen.app/xrpc/app.bsky.feed.describeFeedGenerator")
           echo "$headers"
           echo "$headers" | grep -i "content-encoding: gzip" > /dev/null || \
             echo "::warning::Response is not gzip-encoded — check compression middleware"


### PR DESCRIPTION
## Summary

- The `Fetch feed skeleton` CI step was making an unauthenticated request to `getFeedSkeleton`, which now returns 401 after the auth change merged in #12. The `-f` flag on curl caused the step to fail.
- Replaces the skeleton fetch with an **auth-enforcement check**: expects HTTP 401, warns if it gets 200 (meaning `FEEDGEN_REQUIRE_AUTH=false` is set), and fails on anything else. This is both a fix and an improvement — it confirms the server is up *and* that auth is working.
- Moves the **gzip compression check** from `getFeedSkeleton` (now auth-protected) to `describeFeedGenerator` (public endpoint), so that check continues to work without credentials.

## Test plan

- [ ] Confirm health-check workflow passes on main after merge
- [ ] Confirm the auth-enforcement step reports "HTTP 401" for the production endpoint
- [ ] Confirm gzip step still reports `content-encoding: gzip`

https://claude.ai/code/session_01KJYqnmZfmeo1WRvCMb3bMB

---
_Generated by [Claude Code](https://claude.ai/code/session_01KJYqnmZfmeo1WRvCMb3bMB)_