### PR TITLE
Fix dev-integration CI: build before run, remove duplicate permissions block

### DIFF
--- a/.github/workflows/dev-integration.yml
+++ b/.github/workflows/dev-integration.yml
@@ -8,9 +8,6 @@ on:
 permissions:
   contents: read
 
-permissions:
-  contents: read
-
 jobs:
   integration:
     runs-on: ubuntu-latest
@@ -26,13 +23,16 @@ jobs:
       - name: Install dependencies
         run: yarn install --frozen-lockfile
 
+      - name: Build
+        run: yarn build
+
       - name: Start feed generator in dev mode
         env:
           FEEDGEN_PORT: 3000
           FEEDGEN_LISTENHOST: 127.0.0.1
           FEEDGEN_PUBLISHER_DID: did:example:ci
           FEEDGEN_REQUIRE_AUTH: 'false'
-        run: yarn start &> /tmp/feed-server.log &
+        run: node dist/index.js &> /tmp/feed-server.log &
 
       - name: Wait for server to be ready
         run: |

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "publishFeed": "ts-node scripts/publishFeedGen.ts",
     "unpublishFeed": "ts-node scripts/unpublishFeedGen.ts",
-    "start": "ts-node src/index.ts",
+    "start": "yarn build && node dist/index.js",
     "build": "tsc",
     "dev": "nodemon --watch src --ext ts --exec \"yarn build && node dist/index.js\""
   },


### PR DESCRIPTION
## What's broken

The `dev-integration` workflow merged in #13 fails immediately because `yarn start` calls `ts-node`, which doesn't resolve `.js`→`.ts` extension imports under `moduleResolution: nodenext` (the tsconfig change from #12). This affects both CI and `yarn start` locally.

There's also a duplicate `permissions: contents: read` block in the workflow (artefact from incremental edits).

## Fix

- **Workflow**: add a `Build` step (`yarn build`) and switch the server start from `yarn start` to `node dist/index.js`
- **package.json**: update `yarn start` to `yarn build && node dist/index.js` so local dev isn't broken either (the `dev` script with nodemon already did this — `start` now matches)
- **Workflow**: remove the duplicate `permissions` block

## Test plan

- [x] `Dev integration test` CI passes on this PR
- [x] `yarn start` launches the server locally without ts-node errors

https://claude.ai/code/session_01KJYqnmZfmeo1WRvCMb3bMB

---
_Generated by [Claude Code](https://claude.ai/code/session_01KJYqnmZfmeo1WRvCMb3bMB)_