### PR TITLE
Fix Jetstream endpoint hostname (jetstream1.us-east.bsky.network)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,7 +9,7 @@ FEEDGEN_SQLITE_LOCATION=":memory:"
 
 # Firehose subscription endpoint
 # Jetstream filters to only post events, reducing bandwidth and memory vs the full firehose
-FEEDGEN_SUBSCRIPTION_ENDPOINT="wss://jetstream.bsky.network"
+FEEDGEN_SUBSCRIPTION_ENDPOINT="wss://jetstream1.us-east.bsky.network"
 
 # Set this to the hostname that you intend to run the service at
 FEEDGEN_HOSTNAME="example.com"

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,7 +18,7 @@ const run = async () => {
     sqliteLocation: maybeStr(process.env.FEEDGEN_SQLITE_LOCATION) ?? ':memory:',
     subscriptionEndpoint:
       maybeStr(process.env.FEEDGEN_SUBSCRIPTION_ENDPOINT) ??
-      'wss://jetstream.bsky.network',
+      'wss://jetstream1.us-east.bsky.network',
     publisherDid:
       maybeStr(process.env.FEEDGEN_PUBLISHER_DID) ?? 'did:example:alice',
     subscriptionReconnectDelay:


### PR DESCRIPTION
## Summary

- Fixes `Error: getaddrinfo ENOTFOUND jetstream.bsky.network` — that hostname doesn't exist
- Updates default `FEEDGEN_SUBSCRIPTION_ENDPOINT` and `.env.example` to `wss://jetstream1.us-east.bsky.network`, which is one of Bluesky's real public Jetstream instances

## Test plan
- [x] Restart the service and confirm the Jetstream connection error is gone
- [x] Confirm posts start appearing in the feed via Jetstream

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KjkbxoF9RZJBab1XvLTWNj

---
_Generated by [Claude Code](https://claude.ai/code/session_01KjkbxoF9RZJBab1XvLTWNj)_