### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/health-check.yml
+++ b/.github/workflows/health-check.yml
@@ -6,6 +6,9 @@ on:
   schedule:
     - cron: '0 */6 * * *'   # every 6 hours
 
+permissions:
+  contents: read
+
 jobs:
   health-check:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/karanshukla/navyfragen-feed/security/code-scanning/1](https://github.com/karanshukla/navyfragen-feed/security/code-scanning/1)

Add an explicit `permissions` block at the workflow root so it applies to all jobs (including `health-check`) unless overridden. Since this workflow only runs shell commands and external HTTP checks, the safest non-breaking baseline is read-only repository contents access.

**Best fix in this file:**  
- Edit `.github/workflows/health-check.yml`.
- Insert a root-level block after `on:` (or before `jobs:`), with:
  - `permissions:`
  - `contents: read`

No imports, methods, or other definitions are needed (YAML workflow only).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
