### PR TITLE
Add periodic backfill every 6 hours to recover missed posts

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -276,6 +276,11 @@ export class FeedGenerator {
     await this.backfill()
     await this.pruneOldPosts()
 
+    // Re-run backfill every 6 hours to recover posts missed due to federation lag
+    setInterval(() => {
+      this.backfill().catch((err) => console.error('Periodic backfill error:', err))
+    }, 6 * 60 * 60 * 1000)
+
     const now = new Date()
     const midnight = new Date(now.getFullYear(), now.getMonth(), now.getDate() + 1)
     setTimeout(() => {


### PR DESCRIPTION
## Summary

- Posts from third-party PDSes (e.g. `eurosky.social`) can be silently dropped when there's a federation lag between the PDS and the Jetstream relay — the event never arrives and the feed never knows it was missed
- The startup backfill already recovers these by querying `searchPosts` for `fragen.navy`, `navyfragen`, and `navyfragen.app`, but it only ran once at startup
- This schedules the same backfill to repeat every 6 hours so delayed posts are eventually indexed without requiring a service restart

---
_Generated by [Claude Code](https://claude.ai/code/session_01UxdirRUQMpap8j5egNPoY3)_